### PR TITLE
Fix BetaView state management

### DIFF
--- a/Geranium/BetaChecker.swift
+++ b/Geranium/BetaChecker.swift
@@ -11,11 +11,11 @@ import SwiftUI
 
 struct BetaView: View {
     @Environment(\.dismiss) var dismiss
+    @State private var textPlaceHorder = UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
+    @State private var validation = ""
+    @State private var isEnrolled = false
+    @State private var timer: Timer?
     var body: some View {
-        @State var textPlaceHorder = UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
-        @State var validation = ""
-        @State var isEnrolled = false
-        var timer: Timer?
         VStack {
             Image(uiImage: Bundle.main.icon!)
                 .cornerRadius(10)


### PR DESCRIPTION
## Summary
- fix `BetaView` so state vars persist across view updates

## Testing
- `swift --version`
- `swiftc Geranium/BetaChecker.swift -o /tmp/testswift` *(fails: no such module SwiftUI)*

------
https://chatgpt.com/codex/tasks/task_e_683f8844b770833088b9dbb1e2da1397