### PR TITLE
Move BetaView state vars

### DIFF
--- a/Geranium/BetaChecker.swift
+++ b/Geranium/BetaChecker.swift
@@ -11,11 +11,12 @@ import SwiftUI
 
 struct BetaView: View {
     @Environment(\.dismiss) var dismiss
+    @State private var textPlaceholder = UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
+    @State private var validation = ""
+    @State private var isEnrolled = false
+    var timer: Timer?
+
     var body: some View {
-        @State var textPlaceHorder = UIDevice.current.identifierForVendor?.uuidString ?? "unknown"
-        @State var validation = ""
-        @State var isEnrolled = false
-        var timer: Timer?
         VStack {
             Image(uiImage: Bundle.main.icon!)
                 .cornerRadius(10)
@@ -26,7 +27,7 @@ struct BetaView: View {
             Text("Please copy your UUID and send it to a developer in charge.")
                 .padding()
                 .multilineTextAlignment(.center)
-            Text(textPlaceHorder)
+            Text(textPlaceholder)
                 .padding()
                 .multilineTextAlignment(.center)
                 .textSelection(.enabled)


### PR DESCRIPTION
## Summary
- move BetaView state variables outside the body
- rename textPlaceHorder to textPlaceholder

## Testing
- `swiftc Geranium/BetaChecker.swift -o /tmp/BetaChecker` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_683f898a7c10833080a6456107e4a37c